### PR TITLE
🔀 Refactor/MainandPortfolio#332 [포트폴리오 드롭다운 분리 및 메인페이지 이미지 위치 수정]

### DIFF
--- a/gongjakso/src/components/common/Input/PortfolioInput.Styled.jsx
+++ b/gongjakso/src/components/common/Input/PortfolioInput.Styled.jsx
@@ -1,0 +1,136 @@
+import styled, { css } from 'styled-components';
+
+export const SelectContainer = styled.div`
+    position: relative;
+    width: 100%;
+`;
+
+export const SelectValue = styled.div`
+    display: block;
+    width: 11rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    /* padding: ${props => (props.$case === 'true' ? '0px 15px' : '13px')}; */
+    font-size: ${({ theme }) => theme.fontSize.m};
+    text-align: center;
+    align-items: center;
+    cursor: pointer;
+    transition: border-color 0.1s ease;
+
+    &:hover {
+        border-color: #007bff;
+    }
+    @media screen and (min-width: 375px) and (max-width: 549px) {
+        font-size: 0.938rem;
+        width: ${props => (props.$case === 'true' ? '7.5rem' : '18rem')};
+    }
+    @media screen and (min-width: 550px) and (max-width: 1023px) {
+        font-size: 1rem;
+        width: ${props => (props.$case === 'true' ? '14rem' : '32rem')};
+    }
+`;
+
+export const OptionList = styled.div`
+    position: absolute;
+    font-family: 'PreMedium';
+    right: -1.45rem;
+    width: 13.6rem;
+    font-size: ${({ theme }) => theme.fontSize.m};
+    margin: ${props =>
+        props.$case === 'true' ? '1.25rem 0rem' : '1.25rem 0rem'};
+    list-style: none;
+    border-radius: 0.25rem;
+    background-color: #fff;
+    z-index: 1;
+    border: 0.063rem solid hsl(0, 0%, 90%);
+    max-height: 18.75rem;
+    overflow-y: ${props => (props.$scroll === 'true' ? 'scroll' : 'hidden')};
+    box-shadow: 0 0.25rem 1.063rem rgba(0, 0, 0, 0.05);
+    .option {
+        font-family: 'PreRegular';
+        padding: 0.938rem;
+        cursor: pointer;
+        border-radius: 0.25rem;
+        transition: background-color 0.1s ease;
+        font-weight: 600;
+        font-size: 1.125rem;
+        padding-left: 1.25rem;
+
+        &:hover {
+            background-color: black;
+            color: white;
+        }
+    }
+    @media screen and (min-width: 375px) and (max-width: 549px) {
+        width: ${props => (props.$case === 'true' ? '9.9rem' : '20.9rem')};
+        right: -1.45rem;
+    }
+    @media screen and (min-width: 550px) and (max-width: 1023px) {
+        width: ${props => (props.$case === 'true' ? '17rem' : '35rem')};
+    }
+`;
+
+export const InputLabel = styled.label`
+    display: inline-block;
+    width: ${props => (props.$islabel === 'true' ? '20%' : '0')};
+    font-weight: 700;
+    font-size: ${({ theme }) => theme.fontSize.lg};
+    font-family: 'PreMedium';
+    display: flex;
+    align-items: center;
+`;
+
+export const InputText = styled.input.attrs(props => ({
+    type: props.type || 'text',
+}))`
+    font-size: ${({ theme }) => theme.fontSize.base};
+    font-family: 'PreMedium';
+    font-weight: 500;
+    padding: 0.625rem 0;
+    border-style: none;
+    border-bottom: 0.08rem solid ${({ theme }) => theme.borderline};
+
+    &:focus {
+        outline: none;
+        border-bottom: 0.063rem solid ${({ theme }) => theme.mainFont};
+    }
+
+    &.warning {
+        gap: 0.625rem;
+        border-bottom: 0.063rem solid ${({ theme }) => theme.repo.open};
+    }
+    /* Hide the spinners in Chrome, Safari, Edge, Opera */
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+
+    /* Hide the spinners in Firefox */
+    -moz-appearance: textfield;
+`;
+
+export const Arrow = styled.img`
+    display: flex;
+    align-items: center;
+
+    justify-content: center;
+`;
+
+export const Div = styled.div`
+    width: 70%;
+
+    display: flex;
+    flex-direction: column;
+`;
+export const Important = styled.div`
+    color: red;
+`;
+export const Important2 = styled.div`
+    font-family: 'PreMedium';
+    font-weight: 500;
+    text-decoration-skip-ink: none;
+    margin-top: 0.5rem;
+    color: ${({ theme }) => theme.subFont};
+`;

--- a/gongjakso/src/components/common/Input/PortfolioInput.jsx
+++ b/gongjakso/src/components/common/Input/PortfolioInput.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useRef, useEffect } from 'react';
+import * as S from './PortfolioInput.Styled';
+import Down from '../../../assets/images/Down.svg';
+import Up from '../../../assets/images/icon.svg';
+
+const SelectInput = props => {
+    const {
+        label,
+        id,
+        error,
+        placeholder,
+        selectOptions,
+        register,
+        registerOptions,
+        onChange,
+    } = props;
+
+    const isLabel = !!label;
+    const [selectedOption, setSelectedOption] = useState('');
+    const [isOpen, setIsOpen] = useState(false);
+    const selectRef = useRef(null); // Ref to select container
+
+    useEffect(() => {
+        const handleClickOutside = event => {
+            if (
+                selectRef.current &&
+                !selectRef.current.contains(event.target)
+            ) {
+                setIsOpen(!isOpen);
+            }
+        };
+        if (isOpen) {
+            window.addEventListener('click', handleClickOutside);
+        }
+
+        return () => {
+            window.removeEventListener('click', handleClickOutside);
+        };
+    }, [isOpen, selectRef]);
+
+    const getSelectedOption = selectedOption => {
+        // If '사용 언어' is selected, return empty string
+        if (selectedOption === '사용 언어') {
+            return '';
+        } else {
+            // Return the selected option
+            return selectedOption;
+        }
+    };
+
+    const handleToggleOpen = () => {
+        setIsOpen(!isOpen);
+    };
+
+    const handleSelectChange = event => {
+        const selectedValue = getSelectedOption(event?.target?.value);
+        setSelectedOption(selectedValue);
+        onChange(selectedValue); // Call the onChange function with the selected value
+    };
+    return (
+        <>
+            <S.InputLabel $islabel={isLabel.toString()} htmlFor={id}>
+                {label}
+            </S.InputLabel>
+            <S.SelectContainer ref={selectRef}>
+                <S.SelectValue
+                    onClick={handleToggleOpen}
+                    $case={props.case.toString()}
+                >
+                    {selectedOption || placeholder}
+                    <S.Arrow src={isOpen ? Up : Down} alt="arrow" />
+                </S.SelectValue>
+                {isOpen && (
+                    <S.OptionList
+                        $case={props.case?.toString()}
+                        $scroll={props.scroll?.toString()}
+                    >
+                        {selectOptions.map((option, index) => (
+                            <li
+                                className="option"
+                                key={index}
+                                onClick={() => {
+                                    handleSelectChange({
+                                        target: { value: option },
+                                    });
+                                    handleToggleOpen();
+                                }}
+                            >
+                                {option}
+                            </li>
+                        ))}
+                    </S.OptionList>
+                )}
+            </S.SelectContainer>
+        </>
+    );
+};
+
+export { SelectInput };

--- a/gongjakso/src/pages/HomePage/HomePage.Styled.jsx
+++ b/gongjakso/src/pages/HomePage/HomePage.Styled.jsx
@@ -660,10 +660,15 @@ export const TeamImg2 = styled(TeamImg)`
     background-size: cover;
     left: 73.5rem;
     top: 18.5rem;
-    @media (max-width: 1270px) {
-        left: 26.5rem;
+    @media (max-width: 1440px) {
+        left: 29.5rem;
         top: 15rem;
-        transform: scale(0.7);
+        transform: scale(0.9);
+    }
+    @media (max-width: 1270px) {
+        left: 25.5rem;
+        top: 14rem;
+        transform: scale(0.9);
     }
     @media screen and (min-width: 375px) and (max-width: 549px) {
         left: 6rem;

--- a/gongjakso/src/pages/Portfolio/MakePortfolio.jsx
+++ b/gongjakso/src/pages/Portfolio/MakePortfolio.jsx
@@ -1,5 +1,5 @@
 import * as S from './Portfolio.Styled';
-import { SelectInput } from '../../components/common/Input/Input';
+import { SelectInput } from '../../components/common/Input/PortfolioInput';
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getMyInfo } from '../../service/profile_service';


### PR DESCRIPTION
# PR 템플릿
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
- 포트폴리오 드롭다운 분리하였습니다.
- 메인페이지에서 이미지가 밖으로 튀어나오는 경우 반응형 추가 처리하였습니다.



### 피드백을 받고 싶은 부분 
<!-- 작업 후 기대 동작(스크린샷) -->
- 포트폴리오 드롭다운 디자인이 맞게 변경되었는지 확인부탁드려요
- 메인페이지 내 해당 이미지가 넘치지 않고 잘 배치되었는지 확인부탁드려요
<img width="162" alt="스크린샷 2025-02-24 오후 10 00 11" src="https://github.com/user-attachments/assets/7ef86d2a-07f6-4d46-b8ed-ba0ce91ec9a2" />

